### PR TITLE
Revert update to 3.5.0 with rollback to 3.4 and bump build number to 1

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-13
+    vmImage: macOS-15
   strategy:
     matrix:
       osx_64_:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.5.0" %}
+{% set version = "3.4" %}
 
 package:
   name: glfw
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/glfw/glfw/archive/{{ version }}.tar.gz
-  sha256: 1abba4007c81bb3c21dad0f1cfff65cf71a5f92d1421016ce7eb236c7458ba9f
+  sha256: c038d34200234d071fae9345bc455e4a8f2f544ab60150765d7704e08f3dac01
   patches:
     # Mostly taken from
     # https://github.com/glfw/glfw/issues/2139
@@ -14,7 +14,7 @@ source:
     - patches_for_conda_forge.patch
 
 build:
-  number: 0
+  number: 1
   # https://abi-laboratory.pro/index.php?view=timeline&l=glfw
   run_exports:
     - {{ pin_subpackage('glfw', max_pin='x') }}


### PR DESCRIPTION
Partial fix for https://github.com/conda-forge/glfw-feedstock/issues/26 .

xref: https://github.com/glfw/glfw/issues/2758

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
